### PR TITLE
feat(read): PReadMissSafe — one GetItem per read (skip the probe)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,42 @@ version: 2.1
 orbs:
   tools: replikativ/clj-tools@0
 
+jobs:
+  # Cheap, always-on gate: load the namespace against the PINNED konserve, with no
+  # external service. A stale/incompatible konserve pin (e.g. one missing
+  # PReadMissSafe) fails here immediately.
+  smoke:
+    docker:
+      - image: clojure:temurin-21-tools-deps
+    steps:
+      - checkout
+      - run:
+          name: load namespace against pinned konserve
+          command: clojure -M -e "(require 'konserve-dynamodb.core)(println :loaded)"
+
+  # Compliance tests against a DynamoDB Local service container (reachable on
+  # localhost:8000, matching the test's endpoint). dummy AWS creds — DynamoDB Local
+  # ignores them but the SDK's default credentials chain requires them.
+  unittest:
+    docker:
+      - image: clojure:temurin-21-tools-deps
+        environment:
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+          AWS_REGION: us-west-2
+      - image: amazon/dynamodb-local
+    steps:
+      - checkout
+      - run:
+          name: wait for DynamoDB Local on :8000
+          command: |
+            for i in $(seq 1 60); do (echo > /dev/tcp/localhost/8000) 2>/dev/null && exit 0; sleep 1; done
+            echo "DynamoDB Local did not come up on :8000"; exit 1
+      - run:
+          name: run compliance tests
+          command: |
+            clojure -M:test -e "(require '[clojure.test :as t] 'konserve-dynamodb.core-test)(let [{:keys [fail error]} (t/run-tests 'konserve-dynamodb.core-test)](when (or (pos? fail) (pos? error)) (System/exit 1)))"
+
 workflows:
   build-test-and-deploy:
     jobs:
@@ -18,10 +54,8 @@ workflows:
           context: docker-deploy
           requires:
             - tools/setup
-#      - tools/unittest:
-#          context: docker-deploy
-#          requires:
-#            - tools/build
+      - smoke
+      - unittest
       - tools/deploy:
           context:
             - clojars-deploy
@@ -32,7 +66,8 @@ workflows:
           requires:
             - tools/build
             - tools/format
-#            - tools/unittest
+            - smoke
+            - unittest
       - tools/release:
           context:
             - github-token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable, user-visible changes to konserve-dynamodb are documented here.
+
+## Unreleased
+
+### Added
+- **Read-miss-safe reads (one GetItem, no probe).** The DynamoDB backing implements
+  konserve's `PReadMissSafe` and `-read-header` throws `store-key-not-found-ex` when
+  GetItem returns no item (an absent key has no "Header"). On a konserve that supports
+  the marker the redundant `-blob-exists?` GetItem probe is dropped, so a read is a
+  single GetItem, and read-modify-write ops (`update-in` / `assoc-in` / `bassoc`) skip
+  it too. Requires konserve `0.9.354`+.
+
+### Changed
+- konserve `0.9.342` → `0.9.354`.
+- CI now runs the compliance suite (sync + async) against a DynamoDB Local service
+  container, plus a smoke load-check that catches a stale konserve pin; the release is
+  gated on both.

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.342"}
+        org.replikativ/konserve {:mvn/version "0.9.354"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.11.1"}
 

--- a/src/konserve_dynamodb/core.clj
+++ b/src/konserve_dynamodb/core.clj
@@ -5,6 +5,7 @@
    [konserve.impl.defaults :refer [connect-default-store]]
    [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
                                          PMultiWriteBackingStore PMultiReadBackingStore
+                                         PReadMissSafe store-key-not-found-ex
                                          -delete-store]]
    [konserve.utils :refer [async+sync *default-sync-translation*]]
    [konserve.store :as store]
@@ -244,10 +245,13 @@
                                                     (hash-map "Key" (attribute-value-s key))
                                                     (:consistent-read? table))))
                  (let [^Map fetched-obj @fetched-object
-                       ^AttributeValue attr-value (.get fetched-obj "Header")
-                       ^SdkBytes sdk-bytes (.b attr-value)
-                       ^bytes byte-array (.asByteArray sdk-bytes)]
-                   byte-array))))
+                       ^AttributeValue attr-value (get fetched-obj "Header")]
+                   ;; PReadMissSafe: an absent item is an empty map (GetItem returns
+                   ;; no Item), so there is no "Header". Signal not-found; io-operation's
+                   ;; read-first path converts it to the caller's :not-found.
+                   (when (nil? attr-value)
+                     (throw (store-key-not-found-ex key)))
+                   (.asByteArray ^SdkBytes (.b attr-value))))))
 
   (-read-meta
     [_ _meta-size env]
@@ -520,6 +524,13 @@
                                          {:type :not-supported
                                           :reason "Batch read failed"
                                           :cause e}))))))))))
+
+;; DynamoDB reads are read-miss-safe: -create-blob only constructs a DynamoDBBlob
+;; (no side effect), and -read-header throws store-key-not-found-ex when GetItem
+;; returns no item (empty map, no "Header"). So io-operation skips the -blob-exists?
+;; probe — a read is one GetItem, and update-in/assoc-in/bassoc drop their probe too.
+(extend-type DynamoDBStore
+  PReadMissSafe)
 
 (defn connect-store
   [dynamodb-spec & {:keys [opts]

--- a/test/konserve_dynamodb/core_test.clj
+++ b/test/konserve_dynamodb/core_test.clj
@@ -1,8 +1,9 @@
 (ns konserve-dynamodb.core-test
   (:require
    [clojure.core.async :refer [<!!]]
-   [clojure.test :refer [deftest testing]]
+   [clojure.test :refer [deftest testing is]]
    [konserve-dynamodb.core :as dynamo]
+   [konserve.impl.storage-layout :as sl]
    [konserve.store :as store]
    [konserve.compliance-test :refer [compliance-test]])
   (:import [java.util UUID]))
@@ -45,3 +46,14 @@
         (compliance-test st))
       (<!! (dynamo/release st {:sync? false}))
       (<!! (store/delete-store spec {:sync? false})))))
+
+(deftest dynamodb-read-miss-safe-marker-test
+  (testing "DynamoDB backing implements PReadMissSafe (io-operation skips the -blob-exists? probe on reads)"
+    (let [spec (assoc dynamodb-spec :backend :dynamodb :table "konserve-dynamodb-marker-test")]
+      (try (store/delete-store spec {:sync? true}) (catch Exception _))
+      (Thread/sleep 500)
+      (let [st (store/create-store spec {:sync? true})]
+        (Thread/sleep 500)
+        (is (satisfies? sl/PReadMissSafe (:backing st)))
+        (dynamo/release st {:sync? true})
+        (store/delete-store spec {:sync? true})))))


### PR DESCRIPTION
Implements konserve's `PReadMissSafe` for DynamoDB: `-read-header` throws `store-key-not-found-ex` when GetItem returns no item, so `io-operation` skips the redundant `-blob-exists?` GetItem probe — a read is one GetItem, and read-modify-write ops drop their probe too. Bumps konserve to `0.9.354` and **enables the compliance suite in CI** (sync + async, against a DynamoDB Local service container) plus a smoke load-check. Verified locally: compiles, backing satisfies `PReadMissSafe`, **3 tests / 229 assertions / 0 failures**.