### PR TITLE
Forward the caller's :config; konserve 0.9.369

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.replikativ/logging {:mvn/version "0.1.3"}
-        org.replikativ/konserve {:mvn/version "0.9.354"}
+        org.replikativ/konserve {:mvn/version "0.9.369"}
         org.replikativ/superv.async {:mvn/version "0.3.50"}
         org.clojure/clojure {:mvn/version "1.11.1"}
 

--- a/src/konserve_dynamodb/core.clj
+++ b/src/konserve_dynamodb/core.clj
@@ -547,7 +547,18 @@
                                             :lock-blob? true}
                        :default-serializer :FressianSerializer
                        :buffer-size        (* 1024 1024)}
-                      (dissoc params :opts :config))]
+                      ;; `:config` IS forwarded now. It used to be dissoc'd,
+                      ;; so the literal above always won and a caller could not
+                      ;; configure compression or encryption at all -- the
+                      ;; blob header carried a 0 whatever they asked for.
+                      ;; Merged onto the defaults rather than replacing them,
+                      ;; so a partial `:config` keeps the rest.
+                      (dissoc params :opts :config)
+                      {:config (merge {:sync-blob? true
+                                       :in-place? true
+                                       :no-backup? true
+                                       :lock-blob? true}
+                                      (:config params))})]
     (connect-default-store backing config)))
 
 (defn delete-store

--- a/src/konserve_dynamodb/core.clj
+++ b/src/konserve_dynamodb/core.clj
@@ -2,7 +2,7 @@
   "DynamoDB based konserve backend."
   (:require
    [clojure.core.async :refer [<!!]]
-   [konserve.impl.defaults :refer [connect-default-store]]
+   [konserve.impl.defaults :refer [connect-default-store normalize-store-config]]
    [konserve.impl.storage-layout :refer [PBackingStore PBackingBlob PBackingLock
                                          PMultiWriteBackingStore PMultiReadBackingStore
                                          PReadMissSafe store-key-not-found-ex
@@ -545,20 +545,27 @@
                                             :in-place? true
                                             :no-backup? true
                                             :lock-blob? true}
-                       :default-serializer :FressianSerializer
                        :buffer-size        (* 1024 1024)}
-                      ;; `:config` IS forwarded now. It used to be dissoc'd,
-                      ;; so the literal above always won and a caller could not
-                      ;; configure compression or encryption at all -- the
-                      ;; blob header carried a 0 whatever they asked for.
-                      ;; Merged onto the defaults rather than replacing them,
-                      ;; so a partial `:config` keeps the rest.
-                      (dissoc params :opts :config)
-                      {:config (merge {:sync-blob? true
-                                       :in-place? true
-                                       :no-backup? true
-                                       :lock-blob? true}
-                                      (:config params))})]
+                      (dissoc params :opts :config))
+        ;; `:config` IS forwarded now. It used to be dissoc'd, so the literal
+        ;; default always won and a caller could not configure compression or
+        ;; encryption at all -- the blob header carried a 0 whatever they
+        ;; asked for. Merged onto the defaults rather than replacing them, so
+        ;; a partial `:config` keeps the rest.
+        ;;
+        ;; Normalised BEFORE our own serializer default is filled: emitting
+        ;; `:default-serializer` would trip konserve's deprecation warning on
+        ;; every connect whatever the caller passed, and filling first would
+        ;; let it occupy the slot and silently drop a caller's older spelling.
+        config (-> config
+                   (assoc :config (merge {:sync-blob? true
+                                          :in-place? true
+                                          :no-backup? true
+                                          :lock-blob? true}
+                                         (:config params)))
+                   normalize-store-config
+                   (update-in [:config :encoding]
+                              #(merge {:serializer :FressianSerializer} %)))]
     (connect-default-store backing config)))
 
 (defn delete-store


### PR DESCRIPTION
`(dissoc params :opts :config)` dropped the caller's `:config` before merging, so the literal default always won and **compression and encryption could not be configured at all** — the blob header carried a 0 whatever was asked for.

Forwarded now, and **merged onto** the defaults rather than replacing them, so a partial `:config` keeps `:sync-blob?` and friends. That also makes konserve 0.9.369's `{:encoding {...}}` reachable, since it lives under `:config`.

`:default-serializer` already worked here — it survived the merge — so this is the compression half only.

### Not integration tested

The suite needs AWS credentials and a DynamoDB table, which my environment does not have. I verified that the namespace loads and formatting is clean. The change is small and mechanical, but **someone with the service should run the suite before release.**